### PR TITLE
chore: Makefile cleanups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,11 +37,12 @@ LXC_BRANCH?=stable-5.0
 HACK_D := $(TOP_LEVEL)/hack
 # helper tools
 TOOLS_D := $(HACK_D)/tools
+export PATH := $(TOOLS_D)/bin:$(PATH)
 REGCLIENT := $(TOOLS_D)/bin/regctl
 REGCLIENT_VERSION := v0.5.1
-export SKOPEO = $(TOOLS_D)/bin/skopeo
+SKOPEO = $(TOOLS_D)/bin/skopeo
 export SKOPEO_VERSION = 1.9.3
-export BATS = $(TOOLS_D)/bin/bats
+BATS = $(TOOLS_D)/bin/bats
 BATS_VERSION := v1.10.0
 # OCI registry
 ZOT := $(TOOLS_D)/bin/zot
@@ -156,9 +157,7 @@ check: lint test go-test
 
 .PHONY: test
 test: stacker $(REGCLIENT) $(SKOPEO) $(ZOT) $(BATS)
-	sudo -E PATH="$$PATH:$(TOOLS_D)/bin" \
-		LXC_BRANCH=$(LXC_BRANCH) \
-		LXC_CLONE_URL=$(LXC_CLONE_URL) \
+	sudo -E \
 		STACKER_BUILD_ALPINE_IMAGE=$(STACKER_BUILD_ALPINE_IMAGE) \
 		STACKER_BUILD_BUSYBOX_IMAGE=$(STACKER_BUILD_BUSYBOX_IMAGE) \
 		STACKER_BUILD_CENTOS_IMAGE=$(STACKER_BUILD_CENTOS_IMAGE) \
@@ -172,10 +171,8 @@ check-cov: lint test-cov
 
 .PHONY: test-cov
 test-cov: stacker-cov $(REGCLIENT) $(SKOPEO) $(ZOT)
-	sudo -E PATH="$$PATH" \
+	sudo -E \
 		-E GOCOVERDIR="$$GOCOVERDIR" \
-		LXC_BRANCH=$(LXC_BRANCH) \
-		LXC_CLONE_URL=$(LXC_CLONE_URL) \
 		STACKER_BUILD_ALPINE_IMAGE=$(STACKER_BUILD_ALPINE_IMAGE) \
 		STACKER_BUILD_BUSYBOX_IMAGE=$(STACKER_BUILD_BUSYBOX_IMAGE) \
 		STACKER_BUILD_CENTOS_IMAGE=$(STACKER_BUILD_CENTOS_IMAGE) \
@@ -185,7 +182,7 @@ test-cov: stacker-cov $(REGCLIENT) $(SKOPEO) $(ZOT)
 		$(patsubst %,test/%.bats,$(TEST))
 
 .PHONY: docker-clone
-docker-clone:
+docker-clone: $(SKOPEO)
 	./tools/oci-copy "$(BUILD_D)/oci-clone" $(STACKER_BUILD_IMAGES)
 
 

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -209,7 +209,7 @@ function zot_teardown {
 
 function _skopeo() {
     [ "$1" = "--version" ] && {
-        "$SKOPEO" "$@"
+        skopeo "$@"
         return
     }
     local uid=""
@@ -222,7 +222,7 @@ function _skopeo() {
     [ -n "$TEST_TMPDIR" ]
     local home="${TEST_TMPDIR}/home"
     [ -d "$home" ] || mkdir -p "$home"
-    HOME="$home" "$SKOPEO" "$@"
+    HOME="$home" skopeo "$@"
 }
 
 function test_copy_buffer_size() {
@@ -264,7 +264,7 @@ EOF
   l1=$(cat oci/blobs/sha256/"$m1" | jq .layers[0].digest | sed  's/sha256://' | tr -d \")
   _skopeo --version
   [[ "$(_skopeo --version)" =~ "skopeo version ${SKOPEO_VERSION}" ]] || {
-    echo "$SKOPEO --version should be ${SKOPEO_VERSION}"
+    echo "skopeo --version should be ${SKOPEO_VERSION}"
     exit 1
   }
   _skopeo copy --format=oci oci:oci:tar containers-storage:test:tar


### PR DESCRIPTION
Clean up makefile for:
 * modify PATH with export to point at TOOLS_D/bin this way when test or any target is executed, the tools are in the path.
 * drop export of SKOPEO , just use it by name in test/.
 * Do not export BATS, it was never used anywhere
 * test targets do not need LXC_BRANCH or LXC_CLONE_URL
 * docker-clone depends on skopeo (tools/oci-copy uses it)